### PR TITLE
fix(ci): lint, docker tag, sldl provisioning

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -55,7 +55,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -37,6 +37,12 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Install .NET SDK (macOS source-build fallback)
+        if: runner.os == 'macOS'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Install dependencies
         run: uv sync
 
@@ -61,7 +67,7 @@ jobs:
           "
 
       - name: Provision sldl binary
-        run: uv run toolcrate sldl --help
+        run: uv run toolcrate sldl-upgrade
         env:
           TOOLCRATE_SLDL_VERSION: ""
 

--- a/src/toolcrate/cli/binary_manager.py
+++ b/src/toolcrate/cli/binary_manager.py
@@ -7,8 +7,8 @@ cannot be executed (e.g. macOS Gatekeeper quarantine on unsigned binaries).
 
 from __future__ import annotations
 
-import io
 import importlib.util
+import io
 import json
 import os
 import platform
@@ -21,7 +21,6 @@ import urllib.request
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 from loguru import logger
 
@@ -45,7 +44,7 @@ class ToolStatus:
     name: str
     command: str
     managed_path: Path
-    system_path: Optional[str]
+    system_path: str | None
     installed: bool
     note: str = ""
 
@@ -54,9 +53,9 @@ class ToolStatus:
 class ToolCheckResult:
     name: str
     command: str
-    executable: Optional[str]
+    executable: str | None
     ok: bool
-    returncode: Optional[int]
+    returncode: int | None
     output: str
     error: str = ""
 
@@ -97,14 +96,14 @@ def managed_executable(command: str) -> Path:
     return managed_bin_dir() / f"{command}{suffix}"
 
 
-def find_managed(command: str) -> Optional[Path]:
+def find_managed(command: str) -> Path | None:
     path = managed_executable(command)
     if path.exists() and os.access(path, os.X_OK):
         return path
     return None
 
 
-def find_executable(command: str) -> Optional[str]:
+def find_executable(command: str) -> str | None:
     managed = find_managed(command)
     if managed:
         return str(managed)
@@ -408,7 +407,7 @@ def verify_command_for_tool(command: str) -> list[str]:
     return ["--help"]
 
 
-def executable_for_status(status: ToolStatus) -> Optional[str]:
+def executable_for_status(status: ToolStatus) -> str | None:
     if status.command in {"shazam-tool", "mdl-tool"}:
         managed = find_managed(status.command)
         return str(managed) if managed else None

--- a/src/toolcrate/cli/mdl.py
+++ b/src/toolcrate/cli/mdl.py
@@ -6,12 +6,12 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from pydub.utils import mediainfo
 
 
-def read_metadata(path: Path) -> Dict[str, Any]:
+def read_metadata(path: Path) -> dict[str, Any]:
     info = mediainfo(str(path))
     tags = info.get("TAG", {}) if isinstance(info.get("TAG"), dict) else {}
     return {
@@ -25,7 +25,7 @@ def read_metadata(path: Path) -> Dict[str, Any]:
     }
 
 
-def main(argv: Optional[List[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="ToolCrate metadata utility")
     parser.add_argument(
         "files",


### PR DESCRIPTION
## Summary
- Lint: modernize typing in `mdl.py` + `binary_manager.py` (UP006/UP045)
- Docker: fix invalid `:-<sha>` tag — replace `{{branch}}-` prefix with `sha-`
- Install-test: provision via `sldl-upgrade` (was `sldl --help`, intercepted by click); add .NET 8 on macOS for source-build fallback

## Test plan
- [ ] CI lint green
- [ ] CI install-test green Linux/Windows
- [ ] CI install-test green macOS (dotnet fallback)
- [ ] Docker build-and-push green